### PR TITLE
Add contact page and responsive footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ SkolaOne follows an **AI-first** roadmap that evolves through several phases:
 The roadmap focuses on building robust, well-tested modules first, then layering AI-driven features as data quality improves. Community feedback shapes priorities along the way.
 
 For a more detailed overview of upcoming milestones, see [docs/roadmap.yaml](docs/roadmap.yaml).
+You can also view the roadmap in your browser at `http://localhost:8000/roadmap/` after running the development server.
+You can reach the team using the contact form at `http://localhost:8000/contact/`.
 
 ---
 

--- a/main/forms.py
+++ b/main/forms.py
@@ -1,0 +1,21 @@
+from django import forms
+
+
+class ContactForm(forms.Form):
+    """Simple contact form."""
+    name = forms.CharField(
+        max_length=100,
+        widget=forms.TextInput(attrs={"class": "form-control", "placeholder": "Your Name"}),
+    )
+    email = forms.EmailField(
+        widget=forms.EmailInput(attrs={"class": "form-control", "placeholder": "you@example.com"})
+    )
+    message = forms.CharField(
+        widget=forms.Textarea(
+            attrs={
+                "class": "form-control",
+                "rows": 5,
+                "placeholder": "Type your message",
+            }
+        )
+    )

--- a/main/tests.py
+++ b/main/tests.py
@@ -17,3 +17,22 @@ class SimplePageTests(TestCase):
         response = self.client.get(reverse("modules"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "modules.html")
+
+    def test_roadmap_page(self):
+        response = self.client.get(reverse("roadmap"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "roadmap.html")
+
+    def test_contact_page_get(self):
+        response = self.client.get(reverse("contact"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "contact.html")
+
+    def test_contact_form_post(self):
+        response = self.client.post(
+            reverse("contact"),
+            {"name": "Tester", "email": "tester@example.com", "message": "Hi"},
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Thank you for reaching out!")

--- a/main/urls.py
+++ b/main/urls.py
@@ -5,4 +5,6 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('about/', views.about, name='about'),
     path('modules/', views.modules, name='modules'),
+    path('roadmap/', views.roadmap, name='roadmap'),
+    path('contact/', views.contact, name='contact'),
 ]

--- a/main/views.py
+++ b/main/views.py
@@ -1,4 +1,8 @@
 from django.shortcuts import render
+from django.contrib import messages
+import yaml
+from pathlib import Path
+from .forms import ContactForm
 
 
 def index(request):
@@ -13,13 +17,37 @@ def about(request):
 
 def modules(request):
     """Display list of project modules."""
-    module_list = [
-        "Akademik",
-        "Asrama",
-        "Keuangan",
-        "Perpustakaan",
-        "HRD",
-        "Inventori",
+    modules = [
+        {"name": "Akademik", "icon": "fa-graduation-cap"},
+        {"name": "Asrama", "icon": "fa-building"},
+        {"name": "Keuangan", "icon": "fa-money-bill-wave"},
+        {"name": "Perpustakaan", "icon": "fa-book"},
+        {"name": "HRD", "icon": "fa-users"},
+        {"name": "Inventori", "icon": "fa-boxes-stacked"},
     ]
-    context = {"modules": module_list}
+    context = {"modules": modules}
     return render(request, "modules.html", context)
+
+
+def roadmap(request):
+    """Display project roadmap from YAML file."""
+    roadmap_file = Path(__file__).resolve().parent.parent / "docs" / "roadmap.yaml"
+    try:
+        with open(roadmap_file, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    except FileNotFoundError:
+        data = {"phases": []}
+    context = {"phases": data.get("phases", [])}
+    return render(request, "roadmap.html", context)
+
+
+def contact(request):
+    """Display contact form and handle submissions."""
+    if request.method == "POST":
+        form = ContactForm(request.POST)
+        if form.is_valid():
+            messages.success(request, "Thank you for reaching out!")
+            form = ContactForm()
+    else:
+        form = ContactForm()
+    return render(request, "contact.html", {"form": form})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django>=5.2.3
+PyYAML>=6.0

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2,3 +2,18 @@ body {
     font-family: "Roboto", Arial, sans-serif;
     background-color: #f8f9fa;
 }
+
+.hero {
+    background: linear-gradient(135deg, #4e73df, #1cc88a);
+    color: #fff;
+    padding: 4rem 2rem;
+    border-radius: 0.5rem;
+}
+
+.card-title {
+    font-weight: 500;
+}
+
+form label {
+    font-weight: 500;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}SkolaOne{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-uQtBvWAEFZkLKoUqbQPkaJv0K97V0dxYiy2TWyd4InENcy+XUG6uHgnIY7qDpiR6Z0w3AV/Q93skgVKp5wxYpQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
     {% block extra_css %}{% endblock %}
 </head>
@@ -27,14 +28,35 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/modules/">Modules</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/roadmap/">Roadmap</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/contact/">Contact</a>
+                    </li>
                 </ul>
             </div>
         </div>
     </nav>
 
+    <div class="container mt-3">
+        {% if messages %}
+            {% for message in messages %}
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            {% endfor %}
+        {% endif %}
+    </div>
+
     <div class="container my-4">
         {% block content %}{% endblock %}
     </div>
+
+    <footer class="bg-light text-center py-3 mt-5">
+        <p class="mb-0">&copy; {% now "Y" %} SkolaOne. All rights reserved.</p>
+    </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     {% block extra_js %}{% endblock %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Contact - SkolaOne{% endblock %}
+{% block content %}
+<h1 class="text-center mb-4">Contact Us</h1>
+<form method="post" novalidate>
+    {% csrf_token %}
+    <div class="mb-3">
+        {{ form.name.label_tag }}
+        {{ form.name }}
+        {% if form.name.errors %}
+        <div class="invalid-feedback d-block">{{ form.name.errors.0 }}</div>
+        {% endif %}
+    </div>
+    <div class="mb-3">
+        {{ form.email.label_tag }}
+        {{ form.email }}
+        {% if form.email.errors %}
+        <div class="invalid-feedback d-block">{{ form.email.errors.0 }}</div>
+        {% endif %}
+    </div>
+    <div class="mb-3">
+        {{ form.message.label_tag }}
+        {{ form.message }}
+        {% if form.message.errors %}
+        <div class="invalid-feedback d-block">{{ form.message.errors.0 }}</div>
+        {% endif %}
+    </div>
+    <button type="submit" class="btn btn-primary">Send</button>
+</form>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% block title %}Home - SkolaOne{% endblock %}
 {% block content %}
-<div class="py-5 text-center bg-white rounded shadow-sm">
-    <h1 class="display-5 fw-bold">Welcome to SkolaOne</h1>
-    <p class="lead mb-4">Modular school management system.</p>
+<div class="hero text-center mb-4">
+    <h1 class="display-5 fw-bold mb-3">Welcome to SkolaOne</h1>
+    <p class="lead">Modular school management system.</p>
+    <a href="/contact/" class="btn btn-light mt-3">Get in Touch</a>
 </div>
 {% endblock %}

--- a/templates/modules.html
+++ b/templates/modules.html
@@ -7,7 +7,8 @@
     <div class="col">
         <div class="card h-100 shadow-sm">
             <div class="card-body text-center">
-                <h5 class="card-title">{{ mod }}</h5>
+                <i class="fas {{ mod.icon }} fa-2x mb-2 text-primary"></i>
+                <h5 class="card-title">{{ mod.name }}</h5>
             </div>
         </div>
     </div>

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Roadmap - SkolaOne{% endblock %}
+{% block content %}
+<h1 class="text-center mb-4">Project Roadmap</h1>
+<div class="accordion" id="roadmapAccordion">
+    {% for phase in phases %}
+    <div class="accordion-item">
+        <h2 class="accordion-header" id="heading{{ forloop.counter }}">
+            <button class="accordion-button {% if not forloop.first %}collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ forloop.counter }}" aria-expanded="{% if forloop.first %}true{% else %}false{% endif %}" aria-controls="collapse{{ forloop.counter }}">
+                {{ phase.name }} - <span class="badge bg-secondary ms-2">{{ phase.status }}</span>
+            </button>
+        </h2>
+        <div id="collapse{{ forloop.counter }}" class="accordion-collapse collapse {% if forloop.first %}show{% endif %}" aria-labelledby="heading{{ forloop.counter }}" data-bs-parent="#roadmapAccordion">
+            <div class="accordion-body">
+                <p>{{ phase.description }}</p>
+                {% if phase.completed %}
+                <ul>
+                    {% for item in phase.completed %}
+                    <li>{{ item }}</li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    {% empty %}
+    <p>No roadmap data available.</p>
+    {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- integrate a contact form using Django forms
- expose `/contact/` route with template and tests
- include success messages and new footer
- link to contact page from README and navigation

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_6850f7e4802883318fbbcd24fa78709f